### PR TITLE
Fix IPv6 bracket logic

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -283,12 +283,12 @@ net.ipv6.conf.all.forwarding = 1" >/etc/sysctl.d/wg.conf
 
 function newClient() {
 	# If SERVER_PUB_IP is IPv6, add brackets if missing
-	if [[ ${SERVER_PUB_IP} =~ .*:.* ]]; then
-		if [[ ${SERVER_PUB_IP} != *"["* ]] || [[ ${SERVER_PUB_IP} != *"]"* ]]; then
-			SERVER_PUB_IP="[${SERVER_PUB_IP}]"
-		fi
-	fi
-	ENDPOINT="${SERVER_PUB_IP}:${SERVER_PORT}"
+       if [[ ${SERVER_PUB_IP} =~ .*:.* ]]; then
+               if [[ ${SERVER_PUB_IP} != *"["* ]] && [[ ${SERVER_PUB_IP} != *"]"* ]]; then
+                       SERVER_PUB_IP="[${SERVER_PUB_IP}]"
+               fi
+       fi
+       ENDPOINT="${SERVER_PUB_IP}:${SERVER_PORT}"
 
 	echo ""
 	echo "Client configuration"


### PR DESCRIPTION
## Summary
- ensure IPv6 addresses are only bracketed when they have no brackets

## Testing
- `shellcheck -e SC1091,SC1117,SC2001,SC2034 wireguard-install.sh` *(fails: command not found)*
- `shfmt -d wireguard-install.sh` *(fails: command not found)*

